### PR TITLE
Initial Karlsen Support

### DIFF
--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -1,4 +1,4 @@
-import {Client} from '@kaspa/grpc';
+import {Client} from '@karlsen/grpc';
 import {IRPC, RPC as Rpc} from '../types/custom-types';
 
 export {Client};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@kaspa/grpc-node",
+  "name": "@karlsen/grpc-node",
   "version": "1.0.8",
-  "description": "Node gRPC for kaspa-wallet",
+  "description": "Node gRPC for karlsen-wallet",
   "main": "dist/index.js",
   "author": "ASPECTRON Inc.",
   "license": "ISC",
@@ -10,7 +10,7 @@
     "prepublishOnly": "rm -rf ./dist && rm -f package-lock.json && npm install --also=dev && tsc"
   },
   "dependencies": {
-    "@kaspa/grpc": ">=1.4.0"
+    "@karlsen/grpc": "file:../node-karlsen-grpc"
   },
   "devDependencies": {
     "@types/node": "^14.14.9",

--- a/types/custom-types.d.ts
+++ b/types/custom-types.d.ts
@@ -19,12 +19,12 @@ export interface IData{
 }
 export declare type IStream = any;
 
-export interface KaspadPackage extends GrpcObject{
+export interface KarlsendPackage extends GrpcObject{
     RPC: ServiceClientConstructor
 }
 
 export interface MessagesProto extends GrpcObject{
-    protowire: KaspadPackage
+    protowire: KarlsendPackage
 }
 
 export interface SubscriberItem{


### PR DESCRIPTION
Just rename and for now we are using `@karlsen/grpc` module from local installatoion. It will be published later in `npm` registry.